### PR TITLE
Make version bounds more accurate

### DIFF
--- a/hpp.cabal
+++ b/hpp.cabal
@@ -63,8 +63,8 @@ library
                        Hpp.String,
                        Hpp.Tokens,
                        Hpp.Types
-  build-depends:       base >=4.7 && <4.10, directory, time, filepath,
-                       transformers
+  build-depends:       base >=4.8 && <4.10, directory, time >=1.5, filepath,
+                       transformers >=0.4
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall -fno-full-laziness
@@ -73,7 +73,7 @@ library
 
 executable hpp
   main-is:             src/Main.hs
-  build-depends:       hpp, base >=4.7 && <4.10, directory, time, filepath
+  build-depends:       hpp, base >=4.8 && <4.10, directory, time >=1.5, filepath
   hs-source-dirs:      .
   default-language:    Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
`hpp` clearly assumes a GHC 7.10 library environment, so
let's specify some lower-bounds.

Otherwise cabal runs into compile errors such as

```
src/Hpp.hs:17:8:
    Could not find module ‘Data.Void’
    Perhaps you meant
      Data.Word (from base)
      Data.Word (needs flag -package haskell2010-1.1.2.0)
    Use -v to see a list of the files searched for.

src/Hpp/Expr.hs:14:8:
    Could not find module ‘Data.Bifunctor’
    Perhaps you meant Data.Functor (from base)
    Use -v to see a list of the files searched for.

src/Hpp/Types.hs:7:8:
    Could not find module ‘Control.Monad.Trans.Except’
    Perhaps you meant
      Control.Monad.Trans.Cont (from transformers-0.3.0.0)
      Control.Monad.Trans.Error (from transformers-0.3.0.0)
      Control.Monad.Trans.List (from transformers-0.3.0.0)
```