### PR TITLE
Use throwIO instead of error in hppIO

### DIFF
--- a/src/Hpp.hs
+++ b/src/Hpp.hs
@@ -4,7 +4,8 @@
 module Hpp (parseDefinition, preprocess,
             hppReadFile, hppIO, HppCaps, hppFileContents) where
 import Control.Arrow (first)
-import Control.Monad (unless)
+import Control.Exception (throwIO)
+import Control.Monad (unless, (<=<))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -632,10 +633,10 @@ hppIO' cfg env' snk src =
   dischargeHppCaps cfg env' $
   runHpp (liftIO . readLines) (liftIO . snk) (preprocess src)
 
--- | General hpp runner against input source file lines. Any errors
--- encountered are thrown with 'error'.
+-- | General hpp runner against input source file lines. Throws an
+-- 'Error' using 'throwIO' if something goes wrong.
 hppIO :: Config -> Env -> ([String] -> IO ()) -> [String] -> IO ()
-hppIO cfg env' snk = fmap (maybe () (error . show)) . hppIO' cfg env' snk
+hppIO cfg env' snk = maybe (return ()) throwIO <=< hppIO' cfg env' snk
 
 -- | hpp runner that returns output lines.
 hppFileContents :: Config -> Env ->  FilePath -> [String] -> IO (Either Error [String])

--- a/src/Hpp/Types.hs
+++ b/src/Hpp/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances, LambdaCase, Rank2Types #-}
 -- | The core types involved used by the pre-processor.
 module Hpp.Types where
+import Control.Exception (Exception (..))
 import Control.Monad (ap)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Class (MonadTrans, lift)
@@ -47,6 +48,8 @@ data Error = UnterminatedBranch
            | BadCommandLine P.String
            | RanOutOfInput
              deriving (Eq, Ord, Show)
+
+instance Exception Error
 
 -- | Hpp can raise various parsing errors.
 class HasError m where


### PR DESCRIPTION
Using `error` to indicate user errors (rather than bugs) is
widely discouraged. Use `throwIO` in `hppIO` instead. Also,
throwing the `Error` itself allows users to catch the exception
and get a better sense of what went wrong.