### PR TITLE
Ignore -Werror

### DIFF
--- a/src/Hpp/CmdLine.hs
+++ b/src/Hpp/CmdLine.hs
@@ -85,6 +85,8 @@ parseArgs cfg0 = go emptyEnv id cfg0 Nothing . concatMap breakEqs
           go env acc cfg out rst -- We ignore source language specification
         go env acc cfg out ("-traditional":rst) =
           go env acc cfg out rst -- Ignore the "-traditional" flag
+        go env acc cfg out ("-Werror":rst) =
+          go env acc cfg out rst -- Ignore the "-Werror" flag
         go env acc cfg Nothing (file:rst) =
           case curFileNameF cfg of
             Nothing -> go env acc (cfg { curFileNameF = Just file }) Nothing rst


### PR DESCRIPTION
If GHC (8.4.4) is passed `-Werror`, it passes it through to the preprocessor. Ignore it to make builds with `-Werror` work.