### PR TITLE
Fix support for macros with empty argument list

### DIFF
--- a/src/Hpp/Expansion.hs
+++ b/src/Hpp/Expansion.hs
@@ -99,7 +99,12 @@ appParse = droppingWhile isSpaceScan >> checkApp
                         case unscan tok of
                           Just (Important ")") -> return (acc [arg])
                           _ -> replace tok >> getArg (acc . (arg:))
-        goApp = fmap Just (getArg id)
+        goApp = do
+          tok <- awaitJust "appParse goApp"
+          case unscan tok of
+            -- handle macros with empty argument list
+            Just (Important ")") -> return (Just [])
+            _ -> replace tok >> fmap Just (getArg id)
 
 -- | Emit the tokens of a single argument. Returns 'True' if this is
 -- the final argument in an application (indicated by an unbalanced

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -93,10 +93,24 @@ testCommentsAndSplice2 =
             , "Do you\\\n"
             , "understand?\n" ]
 
+testMacroNoArgs :: IO Bool
+testMacroNoArgs =
+  hppHelper (hppConfig emptyHppState)
+            [ "#define FOO() foo"
+            , "bar"
+            , "FOO()"
+            , "baz"
+            ]
+            [ "bar\n"
+            , "foo\n"
+            , "baz\n"
+            ]
+
 main :: IO ()
 main = do results <- sequenceA [ testElse, testIf, testArith1
                                , testCommentsAndSplice1
-                               , testCommentsAndSplice2 ]
+                               , testCommentsAndSplice2
+                               , testMacroNoArgs ]
           if and results
             then do putStrLn (show (length results) ++ " tests passed")
                     exitWith ExitSuccess


### PR DESCRIPTION
Add support for macros with empty argument list. See added test which fails with the following error without the patch:

```
Error running hpp: TooFewArgumentsToMacro 3 "FOO<0>[\"\"]"
```