### PR TITLE
Simplify #line yielding

### DIFF
--- a/src/Hpp/Conditional.hs
+++ b/src/Hpp/Conditional.hs
@@ -10,12 +10,18 @@ import Hpp.Tokens (notImportant, Token(..))
 import Hpp.Types (lineNum, use, HasHppState, HasError, LineNum, TOKEN, String)
 import Prelude hiding (String)
 
--- | Emit a "#HPP line n" directive
+-- | Emit a "#line ln" directive in the output stream
 --
--- This directive is interpreted by HPP to set the lineNum and to emit a proper
--- "#line n" directive in the output stream.
+-- In fact we emit:
+--  - ["#line ln", "\n"] tokens which will be passed directly in the output stream
+--  - ["#", "line", "ln", "\n"] tokens which will be interpreted by HPP to set
+--  the correct line number and will not be reemitted in the output stream.
+--
 yieldLineNum :: LineNum -> [TOKEN]
-yieldLineNum !ln = [Important "#", Important ("HPP line " <> fromString (show ln)), Other "\n"]
+yieldLineNum !ln =
+  [ Important ("#line " <> fromString (show ln)), Other "\n"
+  , Important "#", Important ("line"), Important (fromString (show ln)), Other "\n"
+  ]
 
 getCmd :: [TOKEN] -> Maybe String
 getCmd = aux . dropWhile notImportant

--- a/src/Hpp/Directive.hs
+++ b/src/Hpp/Directive.hs
@@ -14,7 +14,7 @@ import Hpp.Expansion (expandLineState)
 import Hpp.Expr (evalExpr, parseExpr)
 import Hpp.Macro (parseDefinition)
 import Hpp.Preprocessing (prepareInput)
-import Hpp.StringSig (unquote, toChars, sIsPrefixOf, sdrop)
+import Hpp.StringSig (unquote, toChars)
 import Hpp.Tokens (newLine, notImportant, trimUnimportant, detokenize, isImportant, Token(..))
 import Hpp.Types
 import Hpp.Parser (replace, await, insertInputSegment, takingWhile, droppingWhile, onInputSegment, evalParse, onElements, awaitJust, ParserT, Parser)
@@ -136,15 +136,6 @@ directive = lift (onElements (awaitJust "directive")) >>= aux
                         let tokStr = toChars (detokenize toks)
                         throwError $ UserError ln (tokStr++" ("++curFile++")")
           "warning" -> True <$ lift dropLine -- warnings not yet supported
-
-          -- our emitted "#HPP line" pragmas: we need to interpret them to set
-          -- the lineNume and emit proper "#line" pragmas in the output stream.
-          s | "HPP line " `sIsPrefixOf` s
-            -> do
-                let n = sdrop 9 s
-                lift (replace [Important ("#line " <> n)])
-                lineNum .= read (toChars n) - 1
-                pure True
 
           t -> do toks <- lift takeLine
                   ln <- subtract 1 <$> use lineNum


### PR DESCRIPTION
Followup of #11. I've found a better way to fix #6:

> Previously we would use a custom "HPP line" token but it's not needed. We can just emit two kinds of tokens at once.

