### PR TITLE
Fix function-like macro args losing empty trailing/middle args

### DIFF
--- a/src/Hpp/Expansion.hs
+++ b/src/Hpp/Expansion.hs
@@ -97,7 +97,12 @@ appParse = droppingWhile isSpaceScan >> checkApp
         getArg acc = do arg <- fmap trimScan argParse
                         tok <- awaitJust "appParse getArg"
                         case unscan tok of
+                          -- 'argParse' leaves both ')' and ',' on the
+                          -- stream so an empty trailing argument
+                          -- (e.g. @M(a,)@ or @M(a,,b)@) yields an
+                          -- explicit empty list rather than vanishing.
                           Just (Important ")") -> return (acc [arg])
+                          Just (Important ",") -> getArg (acc . (arg:))
                           _ -> replace tok >> getArg (acc . (arg:))
         goApp = do
           tok <- awaitJust "appParse goApp"
@@ -106,16 +111,17 @@ appParse = droppingWhile isSpaceScan >> checkApp
             Just (Important ")") -> return (Just [])
             _ -> replace tok >> fmap Just (getArg id)
 
--- | Emit the tokens of a single argument. Returns 'True' if this is
--- the final argument in an application (indicated by an unbalanced
--- closing parenthesis.
+-- | Emit the tokens of a single argument. The argument terminator
+-- (either @,@ or the closing @)@) is left on the stream for the
+-- caller — this is what lets 'getArg' tell @M(a)@ apart from
+-- @M(a,)@.
 argParse :: (Monad m, HasError m) => ParserT m src Scan [Scan]
 argParse = go id
   where go acc = do tok <- awaitJust "argParse"
                     case unscan tok of
                       Just (Important s)
                         | s == ")" -> replace tok >> return (acc [])
-                        | s == "," -> return (acc [])
+                        | s == "," -> replace tok >> return (acc [])
                         | s == "(" -> do ts <- fmap (tok:) parenthetical
                                          go (acc . (ts++))
                         | otherwise -> go (acc . (tok:))

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -269,6 +269,30 @@ tests =
             , "#line 17\n"
             ]
 
+  -- Empty trailing argument: glibc's mathcalls.h relies on this when
+  -- it expands @__MATHDECL_ALIAS@ into @__MATH_PRECNAME(name,)@. The
+  -- second argument is intentionally empty, and the macro must still
+  -- see /two/ arguments rather than collapsing to one.
+  , hppHelper (remove_line emptyHppState)
+            [ "#define PAIR(a,b) [a|b]"
+            , "PAIR(x,)"
+            ]
+            [ "[x|]\n"
+            , "\n"
+            ]
+
+  -- Empty leading argument and empty middle argument also matter:
+  -- @M(,b)@ → 2 args (first empty), @M(a,,c)@ → 3 args (middle empty).
+  , hppHelper (remove_line emptyHppState)
+            [ "#define TRIO(a,b,c) [a|b|c]"
+            , "TRIO(,b,)"
+            , "TRIO(a,,c)"
+            ]
+            [ "[|b|]\n"
+            , "[a||c]\n"
+            , "\n"
+            ]
+
   ]
 
 main :: IO ()


### PR DESCRIPTION
argParse used to consume the comma terminating an argument while leaving the closing paren on the stream. That asymmetry made `M(a,)` and `M(a)` indistinguishable to getArg — both ended up with a single argument `[a]` — so an empty trailing argument silently vanished.

This trips glibc's `bits/mathcalls.h`: `__MATHDECL_ALIAS` expands to `__MATH_PRECNAME(__fpclassify,)`, hpp dropped the empty second argument, and the macro then complained that
`__MATH_PRECNAME<2>["__fpclassify"]` had too few arguments. Empty middle and leading args (`M(a,,b)`, `M(,b)`) were affected the same way.

Make argParse leave both terminators on the stream and let getArg discriminate: ')' closes the application, ',' starts a fresh (possibly empty) argument. This makes empty trailing (`M(a,)`), empty leading (`M(,b)`), and empty middle (`M(a,,b)`) arguments all expand the way the C standard requires.

Tests added under tests/AsLib.hs cover all three positions.