### PR TITLE
Track current file's directory across nested includes

### DIFF
--- a/hpp.cabal
+++ b/hpp.cabal
@@ -54,5 +54,5 @@ test-suite aslib
   type:       exitcode-stdio-1.0
   main-is:    tests/AsLib.hs
   ghc-options: -Wall
-  build-depends: base, hpp, transformers, bytestring
+  build-depends: base, hpp, transformers, bytestring, directory
   default-language:    Haskell2010

--- a/src/Hpp/Directive.hs
+++ b/src/Hpp/Directive.hs
@@ -18,6 +18,7 @@ import Hpp.StringSig (unquote, toChars)
 import Hpp.Tokens (newLine, notImportant, trimUnimportant, detokenize, isImportant, Token(..))
 import Hpp.Types
 import Hpp.Parser (replace, await, insertInputSegment, takingWhile, droppingWhile, onInputSegment, evalParse, onElements, awaitJust, ParserT, Parser)
+import System.FilePath (takeDirectory)
 import Text.Read (readMaybe)
 import Prelude hiding (String)
 
@@ -46,20 +47,35 @@ droppingSpaces ::(Monad m) => ParserT m src TOKEN ()
 droppingSpaces = droppingWhile notImportant
 
 -- | Run a Stream with a configuration for a new file.
+--
+-- Both 'curFileName' and 'dir' are switched to the new file: the
+-- directory tracks the file currently being preprocessed so quoted
+-- @#include "rel/path.h"@ directives nested inside @fp@ resolve
+-- relative to @fp@'s own directory (C99 §6.10.2 "in a manner that
+-- depends on the implementation"; gcc/clang look in the directory
+-- of the file containing the @#include@). Without this, an included
+-- file living in a subdirectory of the search path could not refer to
+-- siblings via a quoted include — those would be searched only
+-- relative to the original input's directory and the configured
+-- include paths, never under the includer's own subdirectory.
 streamNewFile :: (Monad m, HasHppState m)
               => FilePath -> [[TOKEN]] -> Parser m [TOKEN] ()
 streamNewFile fp s =
-  do (oldCfg,oldLine) <- do st <- getState
-                            let cfg = hppConfig st
-                                cfg' = cfg { curFileNameF = pure fp }
-                                ln = hppLineNum st
-                            -- NOTE: We should *NOT* use a the config lens here
-                            --       because it will mutate the directory which
-                            --       we *don't* want in this instance.
-                            setState (st {hppConfig = cfg', hppLineNum = 1})
-                            return (cfg, ln)
+  do (oldCfg,oldDir,oldLine) <- do st <- getState
+                                   let cfg    = hppConfig st
+                                       cfg'   = cfg { curFileNameF = pure fp }
+                                       oldDir = hppCurDir st
+                                       ln     = hppLineNum st
+                                       newDir = takeDirectory fp
+                                   setState (st { hppConfig  = cfg'
+                                                , hppCurDir  = newDir
+                                                , hppLineNum = 1
+                                                })
+                                   return (cfg, oldDir, ln)
      insertInputSegment
-       s (getState >>= setState . setL lineNum oldLine . setL config oldCfg)
+       s (getState >>= setState . setL lineNum oldLine
+                                . setL config oldCfg
+                                . setL dir oldDir)
 
 -- | Handle preprocessor directives (commands prefixed with an octothorpe).
 directive :: forall m. (Monad m, HasError m, HasHppState m, HasEnv m)

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP #-}
 import Control.Monad.Trans.Except
 import Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Char8 as BS
 import Data.Maybe (fromMaybe)
 import Hpp
 import qualified Hpp.Config as C
@@ -11,6 +12,7 @@ import qualified Hpp.Types as T
 import Data.Monoid ((<>))
 #endif
 
+import System.Directory (withCurrentDirectory)
 import System.Exit
 
 sourceIfdef :: [ByteString]
@@ -37,6 +39,21 @@ hppHelper st src expected =
                       else do putStrLn ("Expected: "++show expected)
                               putStrLn ("Got:      "++show (hppOutput res))
                               return False
+
+-- | File-based variant of 'hppHelper': runs 'runHpp' (which performs IO
+-- to read included files) and checks that the predicate holds on the
+-- emitted output. Used to exercise paths that 'expand' skips, e.g.
+-- @#include "..."@ resolution.
+hppFileHelper :: HppState -> [ByteString] -> ([ByteString] -> Bool) -> IO Bool
+hppFileHelper st src ok = do
+  r <- runExceptT (runHpp st (preprocess src))
+  case r of
+    Left e -> putStrLn ("Error running hpp: " ++ show e) >> return False
+    Right (res, _) ->
+      if ok (hppOutput res)
+        then return True
+        else do putStrLn ("Got: " ++ show (hppOutput res))
+                return False
 
 sourceCommentsAndSplice :: [ByteString]
 sourceCommentsAndSplice =
@@ -292,6 +309,24 @@ tests =
             , "[a||c]\n"
             , "\n"
             ]
+
+  -- Quoted nested includes resolve relative to the includer's
+  -- directory. The fixture in tests/include-data has:
+  --
+  --   sub/outer.h    -- contains  #include "inner.h"
+  --   sub/inner.h    -- contains  inner_marker
+  --
+  -- The test cd's into tests/include-data and feeds an initial
+  -- @#include "sub/outer.h"@. Once outer.h is being preprocessed,
+  -- its sibling @#include "inner.h"@ has to resolve through the
+  -- current-file directory @sub@: without the per-file directory
+  -- tracking it would only be searched relative to the original
+  -- input's directory and never find inner.h.
+  , withCurrentDirectory "tests/include-data" $
+      hppFileHelper
+        (remove_line emptyHppState)
+        ["#include \"sub/outer.h\""]
+        (any (BS.isInfixOf "inner_marker"))
 
   ]
 

--- a/tests/include-data/sub/inner.h
+++ b/tests/include-data/sub/inner.h
@@ -1,0 +1,1 @@
+inner_marker

--- a/tests/include-data/sub/outer.h
+++ b/tests/include-data/sub/outer.h
@@ -1,0 +1,1 @@
+#include "inner.h"


### PR DESCRIPTION
When a preprocessed file does @#include "rel/path.h"@, C99 §6.10.2 requires the implementation to look first in a path that depends on the source of the directive — gcc/clang look in the directory of the file containing the @#include@. HPP was deliberately /not/ updating the @dir@ field on entry to a nested include (per the comment that warned against using the config lens), so quoted includes were always resolved relative to the original input file's directory plus the system include path.

This breaks any header that uses a sibling include from a subdirectory of the search path: the sibling lookup needs the includer's directory, which HPP never had.

Switch 'streamNewFile' to update both @curFileName@ and the @dir@ field when entering an included file, and restore both on exit.

A new test case in tests/AsLib.hs (with fixtures under tests/include-data) exercises the file-resolution path that 'expand' previously skipped: it cd's into the fixture root and preprocesses an initial @#include "sub/outer.h"@, where outer.h itself does @#include "inner.h"@ — only resolvable through the includer's own directory.