### PR TITLE
Add ignoreUnknownDirectives and ignoreHaskellComments config options

### DIFF
--- a/src/Hpp/Config.hs
+++ b/src/Hpp/Config.hs
@@ -44,6 +44,22 @@ data ConfigF f = Config { curFileNameF        :: f FilePath
                         -- ^ Format string for @\_\_DATE\_\_@.
                         , prepTimeF           :: f TimeString
                         -- ^ Format string for @\_\_TIME\_\_@.
+                        , ignoreUnknownDirectivesF :: f Bool
+                        -- ^ Treat @#@-lines whose command is not a
+                        -- known directive as ordinary text, instead
+                        -- of raising an 'UnknownCommand' error. This
+                        -- mirrors the @-traditional-cpp@ behaviour of
+                        -- GNU cpp that GHC relies on when
+                        -- pre-processing Haskell sources.
+                        , ignoreHaskellCommentsF :: f Bool
+                        -- ^ Treat Haskell line comments (@-- …@) and
+                        -- nestable block comments (@{- … -}@) as
+                        -- opaque regions: any @#@ character inside
+                        -- one is rewritten to whitespace before
+                        -- directive detection, so multi-line
+                        -- @{-# LANGUAGE … #-}@ pragmas and stray @#@
+                        -- in comments do not confuse the directive
+                        -- parser.
                        }
 
 -- | A fully-populated configuration for the pre-processor.
@@ -60,9 +76,12 @@ realizeConfig (Config (Just fileName)
                       (Just inhibitLines)
                       (Just trigraphs)
                       (Just pdate)
-                      (Just ptime)) =
+                      (Just ptime)
+                      (Just ignoreUnknown)
+                      (Just ignoreHsCmts)) =
   Just (Config (pure fileName) (pure paths) (pure spliceLines) (pure comments)
-               (pure inhibitLines) (pure trigraphs) (pure pdate) (pure ptime))
+               (pure inhibitLines) (pure trigraphs) (pure pdate) (pure ptime)
+               (pure ignoreUnknown) (pure ignoreHsCmts))
 realizeConfig _ = Nothing
 
 -- | Extract the current file name from a configuration.
@@ -97,6 +116,16 @@ prepDate = runIdentity . prepDateF
 prepTime :: Config -> TimeString
 prepTime = runIdentity . prepTimeF
 
+-- | Determine whether unknown @#@-directives should be passed through
+-- as ordinary text instead of raising an error.
+ignoreUnknownDirectives :: Config -> Bool
+ignoreUnknownDirectives = runIdentity . ignoreUnknownDirectivesF
+
+-- | Determine whether Haskell comments should be treated as opaque
+-- regions when looking for directives.
+ignoreHaskellComments :: Config -> Bool
+ignoreHaskellComments = runIdentity . ignoreHaskellCommentsF
+
 -- | A default configuration with no current file name set. Note that
 -- long line splicing is enabled, C++-style comments are erased, #line
 -- markers are inhibited, and trigraph replacement is disabled.
@@ -105,6 +134,7 @@ defaultConfigF = Config Nothing (Just [])
                         (Just True) (Just True) (Just False) (Just False)
                         (Just (DateString "??? ?? ????"))
                         (Just (TimeString "??:??:??"))
+                        (Just False) (Just False)
 
 -- | Format a date according to the C spec.
 formatPrepDate :: UTCTime -> DateString
@@ -147,3 +177,13 @@ inhibitLinemarkersL f cfg = (\x -> cfg { inhibitLinemarkersF = pure x })
 replaceTrigraphsL :: Functor f => (Bool -> f Bool) -> Config -> f Config
 replaceTrigraphsL f cfg = (\x -> cfg { replaceTrigraphsF = pure x })
                           <$> f (replaceTrigraphs cfg)
+
+-- | Lens for the "ignore unknown directives" option.
+ignoreUnknownDirectivesL :: Functor f => (Bool -> f Bool) -> Config -> f Config
+ignoreUnknownDirectivesL f cfg = (\x -> cfg { ignoreUnknownDirectivesF = pure x })
+                                 <$> f (ignoreUnknownDirectives cfg)
+
+-- | Lens for the "ignore Haskell comments" option.
+ignoreHaskellCommentsL :: Functor f => (Bool -> f Bool) -> Config -> f Config
+ignoreHaskellCommentsL f cfg = (\x -> cfg { ignoreHaskellCommentsF = pure x })
+                               <$> f (ignoreHaskellComments cfg)

--- a/src/Hpp/Directive.hs
+++ b/src/Hpp/Directive.hs
@@ -8,7 +8,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.State.Strict (StateT)
 import Hpp.Conditional (dropBranch, takeBranch)
-import Hpp.Config (curFileName, curFileNameF)
+import Hpp.Config (curFileName, curFileNameF, ignoreUnknownDirectives)
 import Hpp.Env (lookupKey, deleteKey, insertPair)
 import Hpp.Expansion (expandLineState)
 import Hpp.Expr (evalExpr, parseExpr)
@@ -153,10 +153,21 @@ directive = lift (onElements (awaitJust "directive")) >>= aux
                         throwError $ UserError ln (tokStr++" ("++curFile++")")
           "warning" -> True <$ lift dropLine -- warnings not yet supported
 
-          t -> do toks <- lift takeLine
-                  ln <- subtract 1 <$> use lineNum
-                  throwError $ UnknownCommand ln
-                    (toChars (detokenize (Important t:toks)))
+          t -> do cfg <- use config
+                  if ignoreUnknownDirectives cfg
+                    then
+                      -- Pass the line through as plain text. We have
+                      -- only consumed the command token 't' so far;
+                      -- returning False tells 'macroExpansion' to
+                      -- emit the original line and call 'takeLine'
+                      -- to advance the input — see the 'Important
+                      -- "#":rst' branch in 'macroExpansion'.
+                      pure False
+                    else do
+                      toks <- lift takeLine
+                      ln <- subtract 1 <$> use lineNum
+                      throwError $ UnknownCommand ln
+                        (toChars (detokenize (Important t:toks)))
         aux _ = error "Impossible unimportant directive"
         includeAux :: (LineNum -> FilePath -> HppT src (Parser m [TOKEN]) [String])
                    -> HppT src (Parser m [TOKEN]) ()

--- a/src/Hpp/Preprocessing.hs
+++ b/src/Hpp/Preprocessing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP, OverloadedStrings #-}
+{-# LANGUAGE BangPatterns, CPP, OverloadedStrings, MultiWayIf #-}
 -- | The simplest pre-processing steps are represented as distinct
 -- passes over input lines.
 module Hpp.Preprocessing
@@ -7,6 +7,7 @@ module Hpp.Preprocessing
   , lineSplicing
   , cCommentRemoval
   , cCommentAndTrigraph
+  , gateHaskellComments
   , prepareInput
   ) where
 import Control.Arrow (first)
@@ -17,7 +18,7 @@ import Data.Semigroup ((<>))
 import Data.String (fromString)
 import Hpp.Config
 import Hpp.StringSig
-import Hpp.Tokens (tokenize, Token(..), skipLiteral)
+import Hpp.Tokens (tokenize, Token(..), detokenize, skipLiteral)
 import Hpp.Types (TOKEN, String, HasHppState, getState, config, getL)
 import Prelude hiding (String)
 
@@ -145,19 +146,132 @@ cCommentRemoval' do_trigraphs =
   . map dropOneLineBlockComments
   . (if do_trigraphs then map trigraphReplacement else id)
 
+-- * Haskell comments
+
+-- Note [Gating directive dispatch inside Haskell comments]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- HPP is a C/C++ preprocessor that spots directives by the rule "the
+-- first non-whitespace token on a line is an Important '#'". In
+-- Haskell sources that rule misfires on the closing brace of a
+-- multi-line LANGUAGE pragma:
+--
+--     {-# LANGUAGE CPP
+--               , OverloadedStrings
+--       #-}
+--
+-- The third line starts with @#-}@, which HPP would otherwise dispatch
+-- as the unknown directive @-}@.
+--
+-- When 'ignoreHaskellComments' is enabled we run a small stateful
+-- pass ('gateHaskellComments') over the /tokenized/ line stream. It
+-- tracks Haskell lexical state across lines: nestable @{- ... -}@
+-- block comments, @-- ...@ line comments, @\"...\"@ string literals,
+-- and GHC's 'MultilineStrings' extension (a literal opened with
+-- @\"\"\"@ and closed by the next unescaped @\"\"\"@, which may span
+-- many lines).
+--
+-- For any line that /starts/ inside an open block comment or inside
+-- an open multi-line string we demote a leading @Important \"#\"@
+-- token to @Other \"#\"@. That keeps the @#@ character in the output
+-- byte-for-byte (detokenize concatenates all tokens indiscriminately)
+-- while making the directive detector in "Hpp.Directive" skip it.
+-- Multi-line strings need this for the same reason block comments do
+-- — a body line that begins with @#@ would otherwise dispatch as a
+-- directive even though, in Haskell, it is just string content.
+--
+-- We deliberately do /not/ rewrite the text of comments or strings,
+-- and we do /not/ suppress macro expansion inside them — the only
+-- change is that a stray leading @#@ sitting inside an open block
+-- comment or multi-line string no longer trips directive dispatch.
+
+-- | Lexical states tracked by 'gateHaskellComments'.
+data HsLex = HsCode
+           | HsBlockCmt {-# UNPACK #-} !Int
+           | HsLineCmt
+           | HsString
+           | HsMultiString
+
+-- | See Note [Gating directive dispatch inside Haskell comments].
+gateHaskellComments :: [[TOKEN]] -> [[TOKEN]]
+gateHaskellComments = go HsCode
+  where
+    go _ []         = []
+    go st (ln:lns)  =
+      let demoteHere = case st of
+                         HsBlockCmt _  -> True
+                         HsMultiString -> True
+                         _             -> False
+          ln'  | demoteHere = demoteLeadingHash ln
+               | otherwise  = ln
+          stEnd = walk st (toChars (detokenize ln))
+          -- A Haskell line comment terminates at the physical line
+          -- break, so any HsLineCmt state at end-of-line resets to
+          -- HsCode for the following line.
+          stNext = case stEnd of HsLineCmt -> HsCode; s -> s
+      in ln' : go stNext lns
+
+    -- Demote the first Important "#" encountered to an Other token so
+    -- the directive detector skips it. Leading whitespace / Other
+    -- tokens pass through unchanged. If the line's first Important
+    -- token is not "#", we leave it alone.
+    demoteLeadingHash :: [TOKEN] -> [TOKEN]
+    demoteLeadingHash (Other s : rest) = Other s : demoteLeadingHash rest
+    demoteLeadingHash (Important "#" : rest) = Other "#" : rest
+    demoteLeadingHash ln = ln
+
+    walk :: HsLex -> [Char] -> HsLex
+    walk st []                          = st
+    walk HsCode ('{':'-':rest)          = walk (HsBlockCmt 1) rest
+    walk HsCode ('-':'-':rest)          = walk HsLineCmt rest
+    -- The triple-quote pattern must precede the single-quote one:
+    -- Haskell pattern matching is order-sensitive and a leading
+    -- @\"@ would otherwise win and start a regular string.
+    walk HsCode ('"':'"':'"':rest)      = walk HsMultiString rest
+    walk HsCode ('"':rest)              = walk HsString rest
+    walk HsCode (_:rest)                = walk HsCode rest
+    walk (HsBlockCmt n) ('{':'-':rest)  = walk (HsBlockCmt (n+1)) rest
+    walk (HsBlockCmt n) ('-':'}':rest)  =
+      walk (if n <= 1 then HsCode else HsBlockCmt (n-1)) rest
+    walk (HsBlockCmt n) (_:rest)        = walk (HsBlockCmt n) rest
+    walk HsLineCmt (_:rest)             = walk HsLineCmt rest
+    -- Inside a string literal, backslash escapes consume the next
+    -- character so an escaped @\\\"@ doesn't prematurely close it.
+    walk HsString ('\\':_:rest)         = walk HsString rest
+    walk HsString ('"':rest)            = walk HsCode rest
+    walk HsString (_:rest)              = walk HsString rest
+    -- Multi-line strings (GHC's MultilineStrings extension): same
+    -- escape handling as a regular string, but the close delimiter
+    -- is @\"\"\"@. The escape pattern must come first so an escaped
+    -- quote inside the body — e.g. @\\\"@ — does not contribute to
+    -- a stray triple-quote terminator.
+    walk HsMultiString ('\\':_:rest)        = walk HsMultiString rest
+    walk HsMultiString ('"':'"':'"':rest)   = walk HsCode rest
+    walk HsMultiString (_:rest)             = walk HsMultiString rest
+
 prepareInput :: (Monad m, HasHppState m) => m ([String] -> [[TOKEN]])
 prepareInput =
   do cfg <- getL config <$> getState
-     case () of
-       _ | eraseCComments cfg && spliceLongLines cfg
-           && not (inhibitLinemarkers cfg) -> pure normalCPP
-       _ | (eraseCComments cfg && spliceLongLines cfg
-            && (not (replaceTrigraphs cfg))) ->
-           pure haskellCPP
-       _ | not (any ($ cfg) [ eraseCComments
-                            , spliceLongLines
-                            , replaceTrigraphs ]) -> pure onlyMacrosCPP
-       _ | otherwise -> pure (genericConfig cfg)
+     let gate | ignoreHaskellComments cfg = gateHaskellComments
+              | otherwise                 = id
+     let cpp = if
+          | eraseCComments cfg
+          , spliceLongLines cfg
+          , not (inhibitLinemarkers cfg)
+          -> normalCPP
+
+          | eraseCComments cfg
+          , spliceLongLines cfg
+          , not (replaceTrigraphs cfg)
+          -> haskellCPP
+
+          | not (eraseCComments cfg)
+          , not (spliceLongLines cfg)
+          , not (replaceTrigraphs cfg)
+          -> onlyMacrosCPP
+
+          | otherwise
+          -> genericConfig cfg
+     pure (gate . cpp)
 
 -- * HPP configurations
 

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -82,6 +82,15 @@ remove_comments = T.over T.config (T.setL C.eraseCCommentsL True)
 remove_line :: HppState -> HppState
 remove_line = T.over T.config (T.setL C.inhibitLinemarkersL True)
 
+-- | Pass unknown @#@-directives through as plain text instead of
+-- raising an error.
+ignoreUnknown :: HppState -> HppState
+ignoreUnknown = T.over T.config (T.setL C.ignoreUnknownDirectivesL True)
+
+-- | Treat Haskell comments as opaque when looking for directives.
+haskellComments :: HppState -> HppState
+haskellComments = T.over T.config (T.setL C.ignoreHaskellCommentsL True)
+
 add_definition :: ByteString -> ByteString -> HppState -> HppState
 add_definition k v s = fromMaybe (error "Preprocessor definition did not parse")
                                  (addDefinition k v s)
@@ -361,6 +370,184 @@ tests =
             [ "\"\" foo\n"
             , "\n"
             ]
+
+  -- ignoreUnknownDirectives: unknown '#'-commands pass through unchanged
+  -- (mirrors -traditional-cpp's permissive handling of Haskell pragmas
+  -- whose closing @#-}@ lands on its own line).
+  , hppHelper (ignoreUnknown $ remove_line emptyHppState)
+            [ "before"
+            , "  #-}"
+            , "after"
+            ]
+            [ "before\n"
+            , "  #-}\n"
+            , "after\n"
+            , "\n"
+            ]
+
+  -- Known directives are still processed when the option is on.
+  , hppHelper (ignoreUnknown $ remove_line $ add_definition "FOO" "1" emptyHppState)
+            sourceIfdef ["x = 42\n","\n"]
+
+  -- ignoreHaskellComments: the closing brace of a multi-line Haskell
+  -- pragma ('  #-}') begins inside an open '{-' block comment. The
+  -- gating pass demotes the leading '#' token so directive dispatch
+  -- skips it, and the bytes are emitted unchanged.
+  , hppHelper (haskellComments $ remove_line emptyHppState)
+            [ "{-# LANGUAGE CPP"
+            , "           , OverloadedStrings"
+            , "  #-}"
+            , "module M where"
+            , "x = 1"
+            ]
+            [ "{-# LANGUAGE CPP\n"
+            , "           , OverloadedStrings\n"
+            , "  #-}\n"
+            , "module M where\n"
+            , "x = 1\n"
+            , "\n"
+            ]
+
+  -- Nested block comments are tracked: an inner '{-' inside an outer
+  -- '{-' bumps the depth so a single '-}' stays inside the outermost
+  -- comment and the '#-}' line remains gated.
+  , hppHelper (haskellComments $ remove_line emptyHppState)
+            [ "{- outer {- inner"
+            , "  #-}"
+            , "  still in outer -}"
+            , "-}"
+            , "x = 1"
+            ]
+            [ "{- outer {- inner\n"
+            , "  #-}\n"
+            , "  still in outer -}\n"
+            , "-}\n"
+            , "x = 1\n"
+            , "\n"
+            ]
+
+  -- A '{-' appearing inside a string literal should not open a
+  -- Haskell block comment, so the directive that follows is still
+  -- dispatched normally.
+  , hppHelper (haskellComments $ add_definition "FOO" "1"
+               $ remove_line emptyHppState)
+            [ "s = \"{- not a comment -}\""
+            , "#ifdef FOO"
+            , "y = 42"
+            , "#endif"
+            ]
+            [ "s = \"{- not a comment -}\"\n"
+            , "y = 42\n"
+            , "\n"
+            ]
+
+  -- A multi-line Haskell string literal continued via the
+  -- backslash-gap syntax ('\' at end of one line, '\' at the start
+  -- of the next) keeps HsString state alive across lines. A '{-'
+  -- written inside such a string must not open a Haskell block
+  -- comment — otherwise the open comment would persist past the
+  -- closing '"' and demote the leading '#' of the following
+  -- directive, leaving '#ifdef FOO' to pass through as plain text.
+  -- This test uses 'defaultCfg' so that 'spliceLongLines' is off
+  -- and the '\' line endings reach 'gateHaskellComments' intact.
+  , hppHelper (haskellComments . remove_line . add_definition "FOO" "1"
+              $ defaultCfg)
+            [ "s = \"open {- gap \\"
+            , "    \\ end\""
+            , "#ifdef FOO"
+            , "y = 42"
+            , "#endif"
+            ]
+            [ "s = \"open {- gap \\\n"
+            , "    \\ end\"\n"
+            , "y = 42\n"
+            ]
+
+  -- Same scenario, but the '{-' appears on the /second/ line of the
+  -- multi-line string (after the gap closes). The string was opened
+  -- on the first line, so HsString state must be carried across the
+  -- gap into the second line — otherwise a fresh HsCode walk would
+  -- see '{-' open an unclosed block comment and the trailing
+  -- '#ifdef FOO' would be demoted to plain text.
+  , hppHelper (haskellComments . remove_line . add_definition "FOO" "1"
+              $ defaultCfg)
+            [ "s = \"first \\"
+            , "    \\ {- still in string \\"
+            , "    \\ end\""
+            , "#ifdef FOO"
+            , "y = 42"
+            , "#endif"
+            ]
+            [ "s = \"first \\\n"
+            , "    \\ {- still in string \\\n"
+            , "    \\ end\"\n"
+            , "y = 42\n"
+            ]
+
+  -- GHC's MultilineStrings extension: a literal opens with '"""' and
+  -- closes at the next '"""', and may span many lines. The body of a
+  -- multi-line string can contain text that looks like a directive
+  -- ('#define INSIDE 1' below) — that line must pass through as
+  -- string content rather than dispatch as a directive. As a
+  -- corollary, INSIDE must NOT be defined: the bare 'INSIDE' that
+  -- appears after the closing '"""' is expected to remain
+  -- unexpanded. A real '#define FOO 42' after the string then
+  -- dispatches normally and 'FOO' expands to 42 — proving the
+  -- closing '"""' returned the state machine to HsCode.
+  , hppHelper (haskellComments . remove_line $ defaultCfg)
+            [ "before"
+            , "s = \"\"\""
+            , "#define INSIDE 1"
+            , "still in string"
+            , "\"\"\""
+            , "INSIDE"
+            , "#define FOO 42"
+            , "FOO"
+            ]
+            [ "before\n"
+            , "s = \"\"\"\n"
+            , "#define INSIDE 1\n"
+            , "still in string\n"
+            , "\"\"\"\n"
+            , "INSIDE\n"
+            , "42\n"
+            ]
+
+  -- A '{-' inside a multi-line string must not open a Haskell block
+  -- comment, and a '#ifdef'/'#endif' pair inside one must not run
+  -- conditional skipping. Without proper '"""' tracking the opening
+  -- 'foo = """' would walk as three single-quote toggles and end in
+  -- HsString rather than HsMultiString; the body's '#ifdef
+  -- NEVER_DEFINED' would then dispatch (HsString does not gate
+  -- '#'), the false branch would swallow 'would skip', and the
+  -- output would be missing the body lines.
+  , hppHelper (haskellComments . remove_line $ defaultCfg)
+            [ "foo = \"\"\""
+            , "{- not a comment"
+            , "#ifdef NEVER_DEFINED"
+            , "would skip"
+            , "#endif"
+            , "-}"
+            , "\"\"\""
+            , "after"
+            ]
+            [ "foo = \"\"\"\n"
+            , "{- not a comment\n"
+            , "#ifdef NEVER_DEFINED\n"
+            , "would skip\n"
+            , "#endif\n"
+            , "-}\n"
+            , "\"\"\"\n"
+            , "after\n"
+            ]
+
+  -- Outside a Haskell block comment, a regular '#'-prefixed line is
+  -- still dispatched as a directive even with ignoreHaskellComments
+  -- on. (Sanity check: the gate only fires on lines that begin inside
+  -- an open block comment.)
+  , hppHelper (haskellComments $ remove_line
+               $ add_definition "FOO" "1" emptyHppState)
+            sourceIfdef ["x = 42\n","\n"]
 
   ]
 


### PR DESCRIPTION
These two new Config options let callers adapt HPP to Haskell source without preprocessing input text.

- ignoreUnknownDirectives: when set, a '#'-prefixed line whose command is not a recognised directive is emitted as plain text instead of raising UnknownCommand. Mirrors -traditional-cpp's permissive handling that GHC relies on.

- ignoreHaskellComments: when set, a small state machine tracks Haskell lexical state (nestable '{- -}' block comments, '-- …' line comments, '"…"' string literals) across lines of the tokenized stream. For any line that starts inside an open block comment, a leading Important "#" token is demoted to Other "#" so the directive detector skips it. Output bytes are unchanged — detokenize treats Important and Other identically. This keeps the closing '#-}' of a multi-line LANGUAGE pragma from being dispatched as an unknown directive.

Tests cover: #-directives passing through as plain text, known directives still dispatched with the option on, pragma bytes emitted unchanged with gating, nested block comments, strings preventing false comment openers, and sanity check that ordinary directives still dispatch outside comments.