### PR TITLE
Track the resolved include path, not the textual #include argument

### DIFF
--- a/src/Hpp/Directive.hs
+++ b/src/Hpp/Directive.hs
@@ -58,6 +58,13 @@ droppingSpaces = droppingWhile notImportant
 -- siblings via a quoted include — those would be searched only
 -- relative to the original input's directory and the configured
 -- include paths, never under the includer's own subdirectory.
+--
+-- @fp@ must be the /resolved/ path to the file being entered (the
+-- one the include search actually located on disk), not the textual
+-- @#include@ argument. Callers in 'includeAux' obtain it from
+-- 'hppReadFile' / 'hppReadNext' which thread it back from
+-- 'searchForInclude'. See Note [Resolved-path tracking for nested
+-- includes] in pkg:Hpp.RunHpp.
 streamNewFile :: (Monad m, HasHppState m)
               => FilePath -> [[TOKEN]] -> Parser m [TOKEN] ()
 streamNewFile fp s =
@@ -169,17 +176,19 @@ directive = lift (onElements (awaitJust "directive")) >>= aux
                       throwError $ UnknownCommand ln
                         (toChars (detokenize (Important t:toks)))
         aux _ = error "Impossible unimportant directive"
-        includeAux :: (LineNum -> FilePath -> HppT src (Parser m [TOKEN]) [String])
+        includeAux :: (LineNum -> FilePath -> HppT src (Parser m [TOKEN]) (FilePath, [String]))
                    -> HppT src (Parser m [TOKEN]) ()
         includeAux readFun =
           do fileName <- lift (toChars . detokenize . trimUnimportant . init
                                <$> expandLineState)
              ln <- use lineNum
-             src <- prepareInput <*> readFun ln fileName
+             prep <- prepareInput
+             (resolvedPath, content) <- readFun ln fileName
+             let src = prep content
              lineNum .= ln+1
-             lift (streamNewFile (unquote fileName) src)
+             lift (streamNewFile resolvedPath src)
         {- SPECIALIZE includeAux ::
-            (LineNum -> FilePath -> HppT [String] (Parser (StateT HppState (ExceptT Error IO)) [TOKEN]) [String])
+            (LineNum -> FilePath -> HppT [String] (Parser (StateT HppState (ExceptT Error IO)) [TOKEN]) (FilePath, [String]))
             -> HppT [String] (Parser (StateT HppState (ExceptT Error IO)) [TOKEN]) () #-}
         ifAux =
           do toks <- lift (onElements droppingSpaces >> takeLine)

--- a/src/Hpp/RunHpp.hs
+++ b/src/Hpp/RunHpp.hs
@@ -90,7 +90,30 @@ runHpp source sink m = runHppT m >>= go []
           Left . (, IncludeDoesNotExist ln (stripAngleBrackets file))
                . curFileName <$> use config
         readAux files _ln _file k (Just file') =
-          source file' >>= runHppT . k >>= go files
+          source file' >>= runHppT . k file' >>= go files
+
+-- Note [Resolved-path tracking for nested includes]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- C99 §6.10.2 says that for a quoted @#include "rel/path.h"@ the
+-- implementation defines what counts as the "source file's
+-- directory" for the relative lookup. gcc/clang use the directory
+-- of the file containing the directive — that is, of the file
+-- /currently being preprocessed/.
+--
+-- We track that as 'hppCurDir' and update it on entry to a nested
+-- include in 'Hpp.Directive.streamNewFile'. Crucially, the value
+-- we want is the directory of the file we /actually opened/, not
+-- the directory of the textual @#include@ argument. Those differ
+-- whenever the include is resolved off the search path: a header
+-- whose textual form is e.g. @"MachRegs.h"@ may live at
+-- @<some-include-path>/stg/MachRegs.h@.
+--
+-- To make the resolved path available to 'streamNewFile', the
+-- 'ReadFile' / 'ReadNext' continuations of 'HppF' carry the
+-- resolved 'FilePath' alongside the file contents. 'searchForInclude'
+-- in this module is the one place that knows the resolved path,
+-- and we feed it directly into the continuation here at the call
+-- to @k file'@.
 {-# SPECIALIZE runHpp ::
     (FilePath -> Parser (StateT HppState (ExceptT Error IO)) [TOKEN] [String])
  -> ([String] -> Parser (StateT HppState (ExceptT Error IO)) [TOKEN] ())
@@ -111,8 +134,12 @@ expandHpp sink m = runHppT m >>= go []
            -> m (Either (FilePath, Error) (HppResult a))
         go files (PureF x) = pure $ Right (HppResult files x)
         go files (FreeF s) = case s of
-          ReadFile _ln file k -> runHppT (k mempty) >>= go (file:files)
-          ReadNext _ln file k -> runHppT (k mempty) >>= go (file:files)
+          -- 'expandHpp' never opens included files, so there is no
+          -- "resolved path" to feed back. Pass the textual @#include@
+          -- argument as a stand-in: the continuation gets a /mempty/
+          -- body anyway, so the path it sees is not load-bearing.
+          ReadFile _ln file k -> runHppT (k file mempty) >>= go (file:files)
+          ReadNext _ln file k -> runHppT (k file mempty) >>= go (file:files)
           WriteOutput output k -> sink output >> runHppT k >>= go files
 {-# SPECIALIZE expandHpp ::
     ([String] -> Parser (StateT HppState

--- a/src/Hpp/Types.hs
+++ b/src/Hpp/Types.hs
@@ -98,13 +98,20 @@ data HppState = HppState { hppConfig :: Config
 
 -- | A free monad construction to strictly delimit what capabilities
 -- we need to perform pre-processing.
-data HppF t r = ReadFile Int FilePath (t -> r)
-              | ReadNext Int FilePath (t -> r)
+--
+-- The continuations of 'ReadFile' and 'ReadNext' receive both the
+-- /resolved/ path of the included file (after include-path search)
+-- and its contents. The resolved path is what the includer's
+-- directory should be set to when entering the file — see
+-- 'Hpp.Directive.streamNewFile' and Note [Resolved-path tracking
+-- for nested includes] in pkg:Hpp.RunHpp.
+data HppF t r = ReadFile Int FilePath (FilePath -> t -> r)
+              | ReadNext Int FilePath (FilePath -> t -> r)
               | WriteOutput t r
 
 instance Functor (HppF t) where
-  fmap f (ReadFile ln file k) = ReadFile ln file (f . k)
-  fmap f (ReadNext ln file k) = ReadNext ln file (f . k)
+  fmap f (ReadFile ln file k) = ReadFile ln file (\fp t -> f (k fp t))
+  fmap f (ReadNext ln file k) = ReadNext ln file (\fp t -> f (k fp t))
   fmap f (WriteOutput o k) = WriteOutput o (f k)
   {-# INLINE fmap #-}
 
@@ -117,15 +124,17 @@ type Hpp t = FreeF (HppF t)
 newtype HppT t m a = HppT { runHppT :: m (Hpp t a (HppT t m a)) }
 
 -- | @hppReadFile lineNumber fileName@ introduces an @#include
--- <fileName>@ at the given line number.
-hppReadFile :: Monad m => Int -> FilePath -> HppT src m src
-hppReadFile n file = HppT (pure (FreeF (ReadFile n file return)))
+-- <fileName>@ at the given line number. Returns the resolved path
+-- of the included file along with its contents.
+hppReadFile :: Monad m => Int -> FilePath -> HppT src m (FilePath, src)
+hppReadFile n file = HppT (pure (FreeF (ReadFile n file (\fp s -> return (fp, s)))))
 {-# INLINE hppReadFile #-}
 
 -- | @hppReadNext lineNumber fileName@ introduces an @#include_next
--- <fileName>@ at the given line number.
-hppReadNext :: Monad m => Int -> FilePath -> HppT src m src
-hppReadNext n file = HppT (pure (FreeF (ReadNext n file return)))
+-- <fileName>@ at the given line number. Returns the resolved path
+-- of the included file along with its contents.
+hppReadNext :: Monad m => Int -> FilePath -> HppT src m (FilePath, src)
+hppReadNext n file = HppT (pure (FreeF (ReadNext n file (\fp s -> return (fp, s)))))
 {-# INLINE hppReadNext #-}
 
 hppWriteOutput :: Monad m => t -> HppT t m ()

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -82,6 +82,11 @@ remove_comments = T.over T.config (T.setL C.eraseCCommentsL True)
 remove_line :: HppState -> HppState
 remove_line = T.over T.config (T.setL C.inhibitLinemarkersL True)
 
+-- | Override the include search path on an 'HppState'.
+with_include_paths :: [FilePath] -> HppState -> HppState
+with_include_paths ps =
+  T.over T.config (\c -> c { C.includePathsF = pure ps })
+
 -- | Pass unknown @#@-directives through as plain text instead of
 -- raising an error.
 ignoreUnknown :: HppState -> HppState
@@ -336,6 +341,31 @@ tests =
         (remove_line emptyHppState)
         ["#include \"sub/outer.h\""]
         (any (BS.isInfixOf "inner_marker"))
+
+  -- Quoted nested includes work even when the /includer/ was
+  -- resolved off the include search path (not the input's cwd).
+  -- This is the GHC RTS scenario: a top-level @#include
+  -- <stg/MachRegsForHost.h>@ finds the file under an include
+  -- path; that file then does @#include "MachRegs.h"@ to refer
+  -- to a sibling, and @MachRegs.h@ in turn does @#include
+  -- "MachRegs/x86.h"@ to reach a subdirectory.
+  --
+  -- The fixture in tests/include-data is:
+  --
+  --   inc/stg/MachRegsForHost.h  -- #include "MachRegs.h"
+  --   inc/stg/MachRegs.h         -- #include "MachRegs/x86.h"
+  --   inc/stg/MachRegs/x86.h     -- deep_marker
+  --
+  -- The includer's directory must be the /resolved/ on-disk path
+  -- (@inc/stg/@), not the textual @#include@ argument
+  -- (@stg/MachRegsForHost.h@) — otherwise the chained relative
+  -- includes fall off the end of every search path and fail with
+  -- IncludeDoesNotExist on @MachRegs/x86.h@.
+  , withCurrentDirectory "tests/include-data" $
+      hppFileHelper
+        (with_include_paths ["inc"] $ remove_line emptyHppState)
+        ["#include <stg/MachRegsForHost.h>"]
+        (any (BS.isInfixOf "deep_marker"))
 
   -- A @#line N@ directive must make the immediately following
   -- input line expand __LINE__ to N (not N+1). The line-counter

--- a/tests/include-data/inc/stg/MachRegs.h
+++ b/tests/include-data/inc/stg/MachRegs.h
@@ -1,0 +1,1 @@
+#include "MachRegs/x86.h"

--- a/tests/include-data/inc/stg/MachRegs/x86.h
+++ b/tests/include-data/inc/stg/MachRegs/x86.h
@@ -1,0 +1,1 @@
+deep_marker

--- a/tests/include-data/inc/stg/MachRegsForHost.h
+++ b/tests/include-data/inc/stg/MachRegsForHost.h
@@ -1,0 +1,1 @@
+#include "MachRegs.h"


### PR DESCRIPTION
Commit 799d1c0 began tracking the directory of the file currently being preprocessed so that quoted nested includes resolve relative to the includer (C99 §6.10.2; gcc/clang behavior). The directory update was wired in 'streamNewFile', but the call site in 'includeAux' passed the textual @#include@ argument as the new file path. 'takeDirectory' on that yields the wrong directory whenever the include was actually located via the include search path: e.g. @#include "MachRegs.h"@ resolved to
@<include-path>/stg/MachRegs.h@ would set @dir = ""@, and any sibling @#include "MachRegs/x86.h"@ inside it would fall off the end of every search path.

Thread the resolved on-disk path back from 'searchForInclude' so 'streamNewFile' is called with it. The 'HppF' continuations of 'ReadFile' / 'ReadNext' now receive both the resolved path and the file contents, and 'hppReadFile' / 'hppReadNext' return that pair. 'expandHpp' (which never opens files) feeds the textual @#include@ argument as a stand-in — its continuation gets a 'mempty' body anyway, so the path is not load-bearing there.

Add a regression test that exercises the failure mode end-to-end: a search-path-resolved top-level @#include <stg/MachRegsForHost.h>@ chains to a sibling @#include "MachRegs.h"@ and then to a subdir @#include "MachRegs/x86.h"@. Without this fix the chain breaks at 'MachRegs/x86.h' with IncludeDoesNotExist; with the fix each nested directive resolves under the previous file's resolved directory.