### PR TITLE
Directive: don't macro-expand #include <...> or "..." arguments

### DIFF
--- a/src/Hpp/Directive.hs
+++ b/src/Hpp/Directive.hs
@@ -14,7 +14,7 @@ import Hpp.Expansion (expandLineState)
 import Hpp.Expr (evalExpr, parseExpr)
 import Hpp.Macro (parseDefinition)
 import Hpp.Preprocessing (prepareInput)
-import Hpp.StringSig (unquote, toChars)
+import Hpp.StringSig (unquote, toChars, uncons)
 import Hpp.Tokens (newLine, notImportant, trimUnimportant, detokenize, isImportant, Token(..))
 import Hpp.Types
 import Hpp.Parser (replace, await, insertInputSegment, takingWhile, droppingWhile, onInputSegment, evalParse, onElements, awaitJust, ParserT, Parser)
@@ -179,13 +179,35 @@ directive = lift (onElements (awaitJust "directive")) >>= aux
         includeAux :: (LineNum -> FilePath -> HppT src (Parser m [TOKEN]) (FilePath, [String]))
                    -> HppT src (Parser m [TOKEN]) ()
         includeAux readFun =
-          do fileName <- lift (toChars . detokenize . trimUnimportant . init
-                               <$> expandLineState)
-             ln <- use lineNum
+          -- Note [Macro expansion in #include arguments]
+          -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          -- C99 §6.10.2 distinguishes three forms of #include:
+          --   #include <h-char-sequence>   -- macros NOT expanded
+          --   #include "q-char-sequence"   -- macros NOT expanded
+          --   #include pp-tokens           -- macros expanded; the
+          --                                   result must be one of
+          --                                   the two forms above
+          -- Without this distinction, a perfectly legal earlier
+          -- definition such as glibc's `#define errno (*__errno_location ())`
+          -- (which the system <errno.h> itself installs) would corrupt
+          -- every subsequent `#include <errno.h>` into
+          -- `#include <(*__errno_location ()).h>` and fail.
+          do toks <- lift (trimUnimportant <$> takeLine)
+             ln  <- subtract 1 <$> use lineNum -- takeLine bumped past the directive
+             let literal = case dropWhile notImportant toks of
+                   Important t : _ -> case uncons t of
+                     Just ('<', _) -> True
+                     Just ('"', _) -> True
+                     _             -> False
+                   _ -> False
+             finalToks <-
+               if literal
+                 then pure toks
+                 else lift (lift (evalParse expandLineState [toks]))
+             let fileName = toChars (detokenize (trimUnimportant finalToks))
              prep <- prepareInput
              (resolvedPath, content) <- readFun ln fileName
              let src = prep content
-             lineNum .= ln+1
              lift (streamNewFile resolvedPath src)
         {- SPECIALIZE includeAux ::
             (LineNum -> FilePath -> HppT [String] (Parser (StateT HppState (ExceptT Error IO)) [TOKEN]) (FilePath, [String]))

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -367,6 +367,24 @@ tests =
         ["#include <stg/MachRegsForHost.h>"]
         (any (BS.isInfixOf "deep_marker"))
 
+  -- C99 §6.10.2: macros must NOT be expanded inside `<...>` or
+  -- `"..."` include arguments. Real-world trigger: glibc's
+  -- <errno.h> installs `#define errno (*__errno_location ())`,
+  -- so any downstream `#include <errno.h>` would otherwise be
+  -- rewritten to `#include <(*__errno_location ()).h>` and fail
+  -- with IncludeDoesNotExist. The `#define` form (with a space
+  -- before the body) produces an object-like macro — the form
+  -- that triggers the bug. add_definition cannot reproduce it
+  -- because the helper concatenates tokens with no separator,
+  -- which parseDefinition reads as function-like.
+  , withCurrentDirectory "tests/include-data" $
+      hppFileHelper
+        (with_include_paths ["macro-in-include"] (remove_line emptyHppState))
+        [ "#define errno (*__errno_location ())"
+        , "#include <errno.h>"
+        ]
+        (any (BS.isInfixOf "errno_marker"))
+
   -- A @#line N@ directive must make the immediately following
   -- input line expand __LINE__ to N (not N+1). The line-counter
   -- semantics here are load-bearing for any caller that resets

--- a/tests/include-data/macro-in-include/errno.h
+++ b/tests/include-data/macro-in-include/errno.h
@@ -1,0 +1,1 @@
+errno_marker


### PR DESCRIPTION
C99 §6.10.2 distinguishes three forms of #include:

  #include <h-char-sequence>   -- macros NOT expanded
  #include "q-char-sequence"   -- macros NOT expanded
  #include pp-tokens           -- macros expanded; result must be
                                  one of the two forms above

includeAux previously called expandLineState unconditionally, so a perfectly legal earlier definition (notably glibc's `#define errno (*__errno_location ())`, installed by the system <errno.h> itself) corrupted every downstream `#include <errno.h>` into `#include <(*__errno_location ()).h>` and failed with IncludeDoesNotExist. Surfaced when preprocessing GHC's rts/include/rts/OSThreads.h chain.

Now we peek at the first important token of the directive line: if it starts with '<' or '"' we leave the line verbatim; otherwise we feed it through expandLineState as before so the '#include MACRO' form still works.