### PR TITLE
Preprocessing: recognize Haskell character literals in walkTraced

### DIFF
--- a/src/Hpp/Preprocessing.hs
+++ b/src/Hpp/Preprocessing.hs
@@ -224,6 +224,23 @@ gateHaskellComments = go HsCode
           (pos+2, HsBlockCmt 1) : aux (HsBlockCmt 1) (pos+2) rest
         aux HsCode pos ('-':'-':rest)             =
           (pos+2, HsLineCmt) : aux HsLineCmt (pos+2) rest
+        -- Haskell character literals. Match conservatively — the
+        -- two-char-body and one-char-body forms — and let longer
+        -- escapes ('\NUL', '\xFF', '\123', etc.) fall through to be
+        -- consumed character-by-character. That fallback is harmless
+        -- in HsCode because the escape's interior characters never
+        -- introduce a comment / string state on their own. The point
+        -- of these patterns is to keep the closing @"@ in a literal
+        -- like @'"'@ from accidentally entering HsString — see line
+        -- @_quotedbl = '"'@ in filepath's System.FilePath.Internal.
+        --
+        -- Order matters: the four-char form must precede the
+        -- three-char one so that @'\''@ is matched as a complete
+        -- escape rather than as @''@ followed by @'@.
+        aux HsCode pos ('\'':'\\':_:'\'':rest)    =
+          aux HsCode (pos+4) rest
+        aux HsCode pos ('\'':_:'\'':rest)         =
+          aux HsCode (pos+3) rest
         -- The triple-quote pattern must precede the single-quote
         -- one: Haskell pattern matching is order-sensitive and a
         -- leading @\"@ would otherwise win and start a regular

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -428,6 +428,29 @@ tests =
             , "\n"
             ]
 
+  -- A Haskell character literal whose body is a double-quote (`'\"'`)
+  -- must not put the state machine into a HsString state — otherwise
+  -- every directive on subsequent lines (here the `#endif`) is hidden
+  -- by demotion and the `#ifndef` is left with no matching close,
+  -- bubbling up as `awaitJust: dropBranch`. Real-world trigger:
+  -- filepath/System/FilePath/Internal.hs line `_quotedbl = '\"'`
+  -- inside a `#ifndef OS_PATH ... #else ... #endif` block.
+  , hppHelper (haskellComments (remove_line emptyHppState))
+            [ "#define OS_PATH"
+            , "#ifndef OS_PATH"
+            , "before = 1"
+            , "#else"
+            , "_quotedbl = '\"'"
+            , "after = 2"
+            , "#endif"
+            , "tail = 3"
+            ]
+            [ "_quotedbl = '\"'\n"
+            , "after = 2\n"
+            , "tail = 3\n"
+            , "\n"
+            ]
+
   -- A @#line N@ directive must make the immediately following
   -- input line expand __LINE__ to N (not N+1). The line-counter
   -- semantics here are load-bearing for any caller that resets


### PR DESCRIPTION
After the comment/string opacity fix, the state machine still treated a Haskell character literal like @'"'@ as the start of HsString — the closing apostrophe was just consumed as a regular character, leaving the state machine inside a never-closed string. Subsequent @#endif@ tokens then ran through demoteTokens, lost their leading @Important "#"@, and the original @#ifndef@ on the enclosing branch eventually ran off the end of the input with @UserError 0 "awaitJust: dropBranch"@. Real-world trigger: filepath's @_quotedbl = '"'@ in System/FilePath/Internal.hs, which lives inside a long @#ifndef OS_PATH ... #else ... #endif@.

Conservatively match the common forms @'X'@ and @'\X'@ in HsCode and skip the literal as a unit. Longer escapes (@'\NUL'@, @'\xFF'@, @'\123'@) fall through to the per-character path, which is harmless in HsCode because their interior characters do not introduce a new lexical state.

Regression test mirrors the filepath shape: a @#ifndef@/@#else@/ @#endif@ block whose else-branch contains a @'"'@ char literal, followed by code that must remain in scope.