### PR TITLE
Hpp.RunHpp: return both textual and resolved include path

### DIFF
--- a/src/Hpp.hs
+++ b/src/Hpp.hs
@@ -7,7 +7,7 @@ module Hpp ( -- * Running the Preprocessor
             -- * Adding Definitions
             parseDefinition, addDefinition,
             -- * Core Types
-             HppT, HppOutput(..)
+             HppT, HppOutput(..), R.IncludedFile(..)
             ) where
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Class (lift, MonadTrans)
@@ -38,8 +38,11 @@ newtype HppT m a =
 instance MonadTrans HppT where
   lift = HppT . lift . lift . lift . lift
 
--- | The result of running hpp
-data HppOutput = HppOutput { hppFilesRead :: [FilePath]
+-- | The result of running hpp. 'hppFilesRead' carries one
+-- 'R.IncludedFile' per @#include@ directive that successfully
+-- opened a file; see that type for the textual-vs-resolved-path
+-- split.
+data HppOutput = HppOutput { hppFilesRead :: [R.IncludedFile]
                            , hppOutput    :: [ByteString] }
 
 -- | Preprocess lines of input.
@@ -69,7 +72,7 @@ streamHpp :: MonadIO m
           => T.HppState
           -> ([ByteString] -> m ())
           -> HppT m a
-          -> ExceptT T.Error m ([FilePath], T.HppState)
+          -> ExceptT T.Error m ([R.IncludedFile], T.HppState)
 streamHpp st snk (HppT h) =
   do (a, st') <- S.runStateT
                      (evalParse

--- a/src/Hpp/RunHpp.hs
+++ b/src/Hpp/RunHpp.hs
@@ -2,7 +2,8 @@
              ScopedTypeVariables, TupleSections, ViewPatterns #-}
 -- | Mid-level interface to the pre-processor.
 module Hpp.RunHpp (preprocess, runHpp, expandHpp,
-                   hppIOSink, hppIO, HppResult(..)) where
+                   hppIOSink, hppIO,
+                   HppResult(..), IncludedFile(..)) where
 import Control.Exception (throwIO)
 import Control.Monad ((>=>))
 import Control.Monad.Trans.Class (lift)
@@ -55,7 +56,29 @@ searchForNextInclude curDir paths =
 
 -- * Running an Hpp Action
 
-data HppResult a = HppResult { hppFilesRead :: [FilePath]
+-- | One file referenced through a @#include@ / @#include_next@
+-- directive. Both representations are retained:
+--
+--   * 'ifInclude' is the textual @#include@ argument exactly as it
+--     appeared in the source after macro expansion — including the
+--     @\<…\>@ or @\"…\"@ delimiters. Useful for reporting / diff
+--     output that wants to echo the original spelling.
+--
+--   * 'ifPath' is the absolute on-disk path 'searchForInclude' (or
+--     'searchForNextInclude') actually located, suitable for
+--     filesystem operations, build-graph dependency tracking, and
+--     attribution back to whichever include-search directory served
+--     the lookup. The IO-less 'expandHpp' variant never opens
+--     included files, so it leaves 'ifPath' empty — @null . ifPath@
+--     is the canonical "this entry has no on-disk resolution"
+--     predicate.
+data IncludedFile = IncludedFile
+  { ifInclude :: !FilePath
+  , ifPath    :: !FilePath
+  }
+  deriving (Eq, Show)
+
+data HppResult a = HppResult { hppFilesRead :: [IncludedFile]
                              , hppResult :: a }
 
 -- | Interpret the IO components of the preprocessor. This
@@ -67,7 +90,7 @@ runHpp :: forall m a src. (MonadIO m, HasHppState m)
        -> HppT src m a
        -> m (Either (FilePath,Error) (HppResult a))
 runHpp source sink m = runHppT m >>= go []
-  where go :: [FilePath]
+  where go :: [IncludedFile]
            -> FreeF (HppF src) a (HppT src m a)
            -> m (Either (FilePath, Error) (HppResult a))
         go files (PureF x) = return $ Right (HppResult files x)
@@ -77,20 +100,21 @@ runHpp source sink m = runHppT m >>= go []
             curDir <- use dir
             let ipaths = includePaths cfg
             mFound <- liftIO $ searchForInclude curDir ipaths file
-            readAux (file:files) ln file k mFound
+            readAux files ln file k mFound
           ReadNext ln file k -> do
             cfg    <- use config
             curDir <- use dir
             let ipaths = includePaths cfg
             mFound <- liftIO $ searchForNextInclude curDir ipaths file
-            readAux (file:files) ln file k mFound
+            readAux files ln file k mFound
           WriteOutput output k -> sink output >> runHppT k >>= go files
 
         readAux _files ln file _ Nothing =
           Left . (, IncludeDoesNotExist ln (stripAngleBrackets file))
                . curFileName <$> use config
-        readAux files _ln _file k (Just file') =
-          source file' >>= runHppT . k file' >>= go files
+        readAux files _ln file k (Just file') =
+          let entry = IncludedFile { ifInclude = file, ifPath = file' }
+          in source file' >>= runHppT . k file' >>= go (entry:files)
 
 -- Note [Resolved-path tracking for nested includes]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,17 +153,24 @@ expandHpp :: forall m a src. (Monad m, HasHppState m, Monoid src)
           -> HppT src m a
           -> m (Either (FilePath,Error) (HppResult a))
 expandHpp sink m = runHppT m >>= go []
-  where go :: [FilePath]
+  where go :: [IncludedFile]
            -> FreeF (HppF src) a (HppT src m a)
            -> m (Either (FilePath, Error) (HppResult a))
         go files (PureF x) = pure $ Right (HppResult files x)
         go files (FreeF s) = case s of
           -- 'expandHpp' never opens included files, so there is no
-          -- "resolved path" to feed back. Pass the textual @#include@
-          -- argument as a stand-in: the continuation gets a /mempty/
-          -- body anyway, so the path it sees is not load-bearing.
-          ReadFile _ln file k -> runHppT (k file mempty) >>= go (file:files)
-          ReadNext _ln file k -> runHppT (k file mempty) >>= go (file:files)
+          -- resolved path to record. Leave 'ifPath' empty to mark
+          -- the absence explicitly — callers that distinguish the
+          -- two paths can use @null . ifPath@ as a "this entry has
+          -- no on-disk resolution" predicate. The continuation gets
+          -- a /mempty/ body, so the path it sees is not load-
+          -- bearing.
+          ReadFile _ln file k ->
+            let entry = IncludedFile { ifInclude = file, ifPath = "" }
+            in runHppT (k file mempty) >>= go (entry:files)
+          ReadNext _ln file k ->
+            let entry = IncludedFile { ifInclude = file, ifPath = "" }
+            in runHppT (k file mempty) >>= go (entry:files)
           WriteOutput output k -> sink output >> runHppT k >>= go files
 {-# SPECIALIZE expandHpp ::
     ([String] -> Parser (StateT HppState
@@ -200,7 +231,7 @@ dischargeHppCaps cfg env' m =
 -- | General hpp runner against input source file lines; can return an
 -- 'Error' value if something goes wrong.
 hppIOSink' :: Config -> Env -> ([String] -> IO ()) -> [String]
-           -> IO (Either Error [FilePath])
+           -> IO (Either Error [IncludedFile])
 hppIOSink' cfg env' snk src =
   fmap (fmap hppFilesRead)
   . dischargeHppCaps cfg env' $
@@ -209,12 +240,12 @@ hppIOSink' cfg env' snk src =
 -- | General hpp runner against input source file lines. Output lines
 -- are fed to the caller-supplied sink function. Any errors
 -- encountered are thrown with 'error'.
-hppIOSink :: Config -> Env -> ([String] -> IO ()) -> [String] -> IO [FilePath]
+hppIOSink :: Config -> Env -> ([String] -> IO ()) -> [String] -> IO [IncludedFile]
 hppIOSink cfg env' snk = hppIOSink' cfg env' snk >=> either throwIO return
 
 -- | hpp runner that returns output lines.
 hppIO :: Config -> Env ->  FilePath -> [String]
-      -> IO (Either Error ([FilePath], [String]))
+      -> IO (Either Error ([IncludedFile], [String]))
 hppIO cfg env' fileName src = do
   r <- newIORef id
   let snk xs = modifyIORef r (. (xs++))

--- a/tests/AsLib.hs
+++ b/tests/AsLib.hs
@@ -12,6 +12,7 @@ import qualified Hpp.Types as T
 import Data.Monoid ((<>))
 #endif
 
+import qualified Data.List as List
 import System.Directory (withCurrentDirectory)
 import System.Exit
 
@@ -53,6 +54,21 @@ hppFileHelper st src ok = do
       if ok (hppOutput res)
         then return True
         else do putStrLn ("Got: " ++ show (hppOutput res))
+                return False
+
+-- | Variant of 'hppFileHelper' that checks 'hppFilesRead' (the list
+-- of files HPP actually opened) against a predicate, rather than the
+-- emitted output.
+hppFilesReadHelper
+  :: HppState -> [ByteString] -> ([IncludedFile] -> Bool) -> IO Bool
+hppFilesReadHelper st src ok = do
+  r <- runExceptT (runHpp st (preprocess src))
+  case r of
+    Left e -> putStrLn ("Error running hpp: " ++ show e) >> return False
+    Right (res, _) ->
+      if ok (hppFilesRead res)
+        then return True
+        else do putStrLn ("Got hppFilesRead: " ++ show (hppFilesRead res))
                 return False
 
 sourceCommentsAndSplice :: [ByteString]
@@ -427,6 +443,28 @@ tests =
             [ "msg = \"REG() in a string literal\"\n"
             , "\n"
             ]
+
+  -- For each #include HPP successfully opened, 'hppFilesRead' must
+  -- return both the textual include argument (with its @<…>@ /
+  -- @"…"@ delimiters intact) and the absolute on-disk path the
+  -- search path actually resolved to. Keeping the two side by side
+  -- lets downstream tooling either echo the original spelling or
+  -- attribute the file to a specific include-search directory; the
+  -- textual form alone is unusable as a filesystem path (delimiters
+  -- still attached) and the resolved form alone loses the original
+  -- spelling.
+  , withCurrentDirectory "tests/include-data" $
+      hppFilesReadHelper
+        (with_include_paths ["macro-in-include"] (remove_line emptyHppState))
+        [ "#include <errno.h>" ]
+        (\fs ->
+            case fs of
+              [f] ->
+                ifInclude f == "<errno.h>"
+                && not ('<' `elem` ifPath f)
+                && not ('>' `elem` ifPath f)
+                && "macro-in-include/errno.h" `List.isSuffixOf` ifPath f
+              _   -> False)
 
   -- A Haskell character literal whose body is a double-quote (`'\"'`)
   -- must not put the state machine into a HsString state — otherwise


### PR DESCRIPTION
hppFilesRead used to be an accumulator of textual @#include@ arguments — the literal string as written in the source, including the @\<…\>@ / @\"…\"@ delimiters. That made the field unusable as a filesystem path (delimiters still attached) and ambiguous in the presence of an include-search path resolution (the same quoted argument can be served from any number of search dirs), so any downstream tool that consumed hppFilesRead saw entries like @"<unistd_ext.h>"@ rather than a usable path.

Switch to a small product type that retains both views:

    data IncludedFile = IncludedFile
      { ifInclude :: !FilePath  -- textual #include argument
      , ifPath    :: !FilePath  -- resolved absolute path
      }

HppResult and HppOutput now carry [IncludedFile]; streamHpp, hppIOSink, hppIOSink', hppIO are retyped accordingly. In the IO-driven runHpp path, the accumulator is populated only after a successful searchForInclude resolution, so 'ifPath' is a real absolute path. The IO-less expandHpp variant — which by design never opens included files — leaves 'ifPath' empty so the absence of an on-disk resolution is explicit; @null . ifPath@ is the canonical predicate.

IncludeDoesNotExist still reports the original textual argument (with brackets stripped via stripAngleBrackets) so error messages are unchanged.

Regression test: a single @#include <errno.h>@ resolved off the search path must record @ifInclude = "<errno.h>"@ and an @ifPath@ that ends in the on-disk subpath with no @<@/@>@ characters.